### PR TITLE
Don't error out if the context doesn't contain the form

### DIFF
--- a/django_helpful/webtest.py
+++ b/django_helpful/webtest.py
@@ -29,6 +29,8 @@ class WebTest(django_webtest.WebTest):
         if getattr(response, 'context', None) is None:
             return
 
+        if form_context_name not in response.context:
+            return
         form = response.context[form_context_name]
         if not form:
             return


### PR DESCRIPTION
In a situation where a) The form submission went fine and b) Another
template has been rendered (without 'form' in it's context) for use
elsewhere, the old code would raise a KeyError.